### PR TITLE
feat: added federation specific credential verifier metadata parameters

### DIFF
--- a/openid-federation-wallet-1_0.md
+++ b/openid-federation-wallet-1_0.md
@@ -391,10 +391,10 @@ constrained DCQL queries in federation-managed metadata. This practice aims to:
 - limit the kinds of Digital Credentials and claims that a Credential
   Verifier is allowed to request from Wallets.
 
-This moves critical configuration and authorization decisions from ad‑hoc,
-per‑instance configuration into a federated, policy-driven framework anchored
-in the Trust Anchor, improving reliability and consistency of participants
-across the ecosystem.
+When these parameters are expressed and enforced through Subordinate
+Statements, as defined in [@!OpenID.Federation], critical configuration and
+authorization decisions move from ad‑hoc, per‑instance configuration into a
+federated, policy-driven framework anchored in the Trust Anchor and the Superior Entities.
 
 # Federation Policies
 


### PR DESCRIPTION
This pull request extends the OpenID Credential Verifier metadata specification to define additional parameters and clarify how federation authorities (such as Trust Anchors) can centrally control and enforce policy on Credential Verifiers in federated environments. The changes introduce new metadata parameters, describe their intended use, and specify how superior entities can set or constrain these parameters using subordinate statements and metadata policies.

The most important changes are:

**New and Extended Metadata Parameters:**

* Defined additional `openid_credential_verifier` metadata parameters: `jwks`, `request_uris`, `response_uris`, `redirect_uris`, and `dcql_query`, including their purpose, usage, and processing rules in federated OpenID4VP scenarios.
* Explained the rationale for extending these parameters to align with a federated, policy-driven trust model, improving reliability and consistency across the ecosystem.

**Federation Policy and Enforcement:**

* Clarified how federation authorities can use subordinate statements to set or restrict `openid_credential_verifier` metadata (such as keys, endpoints, and DCQL queries) for Credential Verifiers, and how these constraints are enforced via `metadata` and `metadata_policy`.
* Specified that Wallets must treat the final, policy-processed metadata as authoritative, rejecting requests that use endpoints or queries not allowed by the evaluated Trust Chain, to prevent endpoint mix-up attacks and enforce credential request restrictions.

**Policy Propagation and Evaluation:**

* Detailed how `metadata_policy` propagates constraints along the Trust Chain and how Wallets should evaluate and enforce these constraints during OpenID4VP interactions.

This PR resolves https://github.com/openid/federation-wallet/issues/11, closes https://github.com/openid/federation-wallet/issues/20, resolves https://github.com/openid/federation-wallet/issues/39

This PR aims to satisfy requests, community claims and real-world implementation evidences as also brought by https://github.com/FIDEScommunity/DIIP